### PR TITLE
Fixed javascript-setup guide using wrong syntax for constructor

### DIFF
--- a/guides/javascript-setup.md
+++ b/guides/javascript-setup.md
@@ -52,7 +52,7 @@ import TelemetryDeck from '@telemetrydeck/sdk';
 
 const td = new TelemetryDeck({
   appID: '<YOUR_APP_ID>'
-  user: '<YOUR_USER_IDENTIFIER>',
+  clientUser: '<YOUR_USER_IDENTIFIER>',
 });
 ```
 
@@ -74,7 +74,7 @@ import crypto from 'crypto';
 
 const td = new TelemetryDeck({
   appID: '<YOUR_APP_ID>'
-  user: '<YOUR_USER_IDENTIFIER>',
+  clientUser: '<YOUR_USER_IDENTIFIER>',
   subtleCrypto: crypto.webcrypto.subtle,
 });
 ```


### PR DESCRIPTION
The JavaScript SDK setup guide contains, what looks to me like, wrong syntax.
It says that we should pass an object with a `user` property to the constructor to specify the user ID, but the actual constructor seems to be using `clientUser` (see: https://github.com/TelemetryDeck/JavaScriptSDK/blob/main/src/telemetrydeck.js#L40C14-L40C14).