### PR TITLE
Top N Query: plural 'dimensions' key

### DIFF
--- a/tql/topN.md
+++ b/tql/topN.md
@@ -13,11 +13,13 @@ A Top N query allows you to list the top N values of a dimension, ordered by a m
 {
   "aggregations": [{ "name": "count", "type": "count" }],
   "dataSource": "telemetry-signals",
-  "dimension": {
-    "dimension": "appVersion",
-    "outputName": "appVersion",
-    "type": "default"
-  },
+  "dimensions": [
+    {
+      "dimension": "appVersion",
+      "outputName": "appVersion",
+      "type": "default"
+    }
+  ],
   "granularity": "all",
   "metric": {
     "ordering": "version",


### PR DESCRIPTION
In #72 I couldn't figure out how to get a referrer overview to work.

Playing around with the example from https://telemetrydeck.com/docs/recipes/views-per-purchase-example/ I noticed that the Top N Query page has a `"dimension": { ... }` entry, not `"dimensions": [ { ... } ]`. Using the plural and array helped. So I guess it's a typo or outdated? Anyway, here's the fix :)