### PR TITLE
Remove TopN Threshold optionality

### DIFF
--- a/tql/topN.md
+++ b/tql/topN.md
@@ -41,4 +41,4 @@ All [default properties](/docs/tql/query/) and the following properties are supp
 | ------------------------------------- | ---------------------------------------------------------------------------------- |
 | [dimension](/docs/tql/dimensionSpec/) | A single DimensionSpec defining the dimension that you want the top taken for.     |
 | [metric](/docs/tql/topNMetricSpec/)   | A TopNMetricSpec object specifying the metric to sort by for the top list.         |
-| **threshold** (optional)              | An integer defining the N in the topN (how many results you want in the top list). |
+| **threshold**                         | An integer defining the N in the topN (how many results you want in the top list). |


### PR DESCRIPTION
When you leave out the `threshold` key, this happens:

> Error: Abort.400: Cannot construct instance of `org.apache.druid.query.topn.TopNQuery`, problem: Threshold cannot be equal to 0. at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 903]: undefined

My TQL is:

```json
{
  "aggregations": [
    {
      "fieldName": "count",
      "name": "Count",
      "type": "count"
    }
  ],
  "dataSource": "telemetry-signals",
  "dimension": {
    "dimension": "referrer",
    "outputName": "Referrer/Link Source",
    "outputType": "STRING",
    "type": "default"
  },
  "granularity": "month",
  "metric": {
    "metric": "Count",
    "type": "numeric"
  },
  "queryType": "topN"
}
```

so the key isn't actually optional *or* the internal default is wrong