### PR TITLE
Add new Grand Rename article explaining why and how it's done

### DIFF
--- a/api/signals-reference.md
+++ b/api/signals-reference.md
@@ -10,9 +10,9 @@ lead: A Signal is the representation of one event happening in one instance of y
 
 Signals are an indication that **an event** happened in your app, which is used by a **user**. Signals consist of these parts:
 
-- **Signal Type** – A string that indicates which kind of event happened.<br>In this case we'll use `applicationDidFinishLaunching`, but it can be `databaseUpdated` or `settingsScreenOpened` or `pizzaModeActivated` (I totally love that last one!)
-- **User Identifer** – A string that identifies your user.<br>This can be an email address or a username, or a random ID that you generate once and store somewhere. It should always be the same for all the signals you send from a certain instance of the app. If you don't supply a user identifier, `TelemetryManager` will generate one for you.
-- **A Metadata Payload** – Metadata is a dictionary `[String: String]` of additional data about your app that might be interesting to analyze.<br>`TelemetryManager` will always add the user's OS Version, Platform, Build Number and App Version to the metadata, but you can specify additional info like, `numberOfEntriesInDatabase` (an int cast to string) or `pizzaModeAnchoviesEnabled` (a Boolean cast to string).
+- **Signal Name** – A string that indicates which kind of event happened.<br>In this case we'll use `applicationDidFinishLaunching`, but it can be `databaseUpdated` or `settingsScreenOpened` or `pizzaModeActivated` (I totally love that last one!)
+- **User Identifer** – A string that identifies your user.<br>This can be an email address or a username, or a random ID that you generate once and store somewhere. It should always be the same for all the signals you send from a certain instance of the app. If you don't supply a user identifier, `TelemetryDeck` will generate one for you.
+- **A Metadata Payload** – Metadata is a dictionary `[String: String]` of additional data about your app that might be interesting to analyze.<br>`TelemetryDeck` will always add the user's OS Version, Platform, Build Number and App Version to the metadata, but you can specify additional info like, `numberOfEntriesInDatabase` (an int cast to string) or `pizzaModeAnchoviesEnabled` (a Boolean cast to string).
 
 As TelemetryDeck is an analytics software, it analyzes events that occur in your apps' life cycles. In TelemetryDeck,
 these events are called _Signals_. You can think about them like this: An **event** occurs, prompting your app to
@@ -50,9 +50,9 @@ Here is an example signal:
 Signals always have a type. This is a short string that describes the event that caused the signal to be sent. It is
 recommended to use short, camel-cased half-sentences like these:
 
-- `appLaunchedRegularly`
-- `appEnteredBackground`
-- `settingsOpened`
+- `App.launchedRegularly`
+- `App.enteredBackground`
+- `Settings.opened`
 
 When you're setting up your [Insights](/docs/api/insights-reference/) later, you'll be able to **filter** by Signal Type.
 
@@ -77,17 +77,35 @@ there. This is highly useful for filtering and aggregation insights.
 
 The default client library will automatically send a base payload with these keys:
 
-- `platform`
-- `systemVersion`
-- `appVersion`
-- `buildNumber`
-- `isSimulator`
-- `isTestFlight`
-- `isAppStore`
-- `modelName`
-- `architecture`
-- `operatingSystem`
-- `targetEnvironment`
+- `TelemetryDeck.AppInfo.buildNumber`
+- `TelemetryDeck.AppInfo.dartVersion`
+- `TelemetryDeck.AppInfo.version`
+- `TelemetryDeck.AppInfo.versionAndBuildNumber`
+- `TelemetryDeck.Device.architecture`
+- `TelemetryDeck.Device.brand`
+- `TelemetryDeck.Device.modelName`
+- `TelemetryDeck.Device.operatingSystem`
+- `TelemetryDeck.Device.orientation`
+- `TelemetryDeck.Device.platform`
+- `TelemetryDeck.Device.screenResolutionWidth`
+- `TelemetryDeck.Device.screenResolutionHeight`
+- `TelemetryDeck.Device.systemMajorVersion`
+- `TelemetryDeck.Device.systemMajorMinorVersion`
+- `TelemetryDeck.Device.systemVersion`
+- `TelemetryDeck.Device.timeZone`
+- `TelemetryDeck.RunContext.extensionIdentifier`
+- `TelemetryDeck.RunContext.isAppStore`
+- `TelemetryDeck.RunContext.isDebug`
+- `TelemetryDeck.RunContext.isSimulator`
+- `TelemetryDeck.RunContext.isTestFlight`
+- `TelemetryDeck.RunContext.language`
+- `TelemetryDeck.RunContext.locale`
+- `TelemetryDeck.RunContext.targetEnvironment`
+- `TelemetryDeck.SDK.name`
+- `TelemetryDeck.SDK.nameAndVersion`
+- `TelemetryDeck.SDK.version`
+- `TelemetryDeck.UserPreference.region`
+- `TelemetryDeck.UserPreference.language`
 
 You can add any additional keys and values, or overwrite existing ones. For example, it might be a good idea to send
 your application's settings with each call. This way, you'll get a good overview of which percentage of your users
@@ -99,7 +117,7 @@ Signals have a "created at" property that is set to the time (in UTC) when the s
 allows you to group them by time.
 
 <div class="alert alert-info" role="alert">
-Note: In a future version of TelemetryDeck, you'll be able to <a href="https://github.com/TelemetryDeck/SwiftClient/issues/19">store signals locally in the app before sending them</a>.
+Note: In a future version of TelemetryDeck, you'll be able to <a href="https://github.com/TelemetryDeck/SwiftSDK/issues/19">store signals locally in the app before sending them</a>.
 If you are using that technique, the server will no longer set the time the signal was created, but it will instead be
 set on the client.
 </div>

--- a/articles/anonymization-how-it-works.md
+++ b/articles/anonymization-how-it-works.md
@@ -15,7 +15,7 @@ headerImage: /docs/images/anonymization-display-image.jpg
 
 Anonymizing data involves transforming it to prevent direct linkage to a person. However, if the original data can be recreated with additional information, the transformation only qualifies as pseudonymization. **GDPR considers data truly anonymized** only if the original data can’t be recreated, even with additional information.
 
-At TelemetryDeck, we even go a step further: the “identification date” is no longer available; “re-identification” is thus ruled out and cannot be performed. Therefore, anonymized data is not personal data anymore. [You can check out our code](https://github.com/TelemetryDeck/SwiftClient/blob/main/Sources/TelemetryClient/SignalManager.swift#L84) to confirm the statement for yourself!
+At TelemetryDeck, we even go a step further: the “identification date” is no longer available; “re-identification” is thus ruled out and cannot be performed. Therefore, anonymized data is not personal data anymore. [You can check out our code](https://github.com/TelemetryDeck/SwiftSDK/blob/main/Sources/TelemetryClient/SignalManager.swift#L84) to confirm the statement for yourself!
 
 ## User identifiers
 

--- a/articles/app-tracking-transparency.md
+++ b/articles/app-tracking-transparency.md
@@ -54,16 +54,15 @@ Here are some directions you could go if you decide to [part ways with analytics
 
 ### No Analytics
 
-A drastic measure would be to just go without and hope your users are messaging you every now and then and telling you how they use your app. This is entirely possible, especially for smaller apps or developers who have impeccable taste – but I wouldn't recommend it.
+A drastic measure would be to just go without and hope your users are messaging you every now and then and telling you how they use your app. This is entirely possible, especially for smaller apps or developers who have impeccable taste – but we wouldn't recommend it.
 
 ### Apple's App Store Analytics
 
-Apple's own analytics are enabled by default, are good for user privacy, and definitely won't trigger the ATT
-dialog. The only problem is, I wouldn't really call them analytics: The information you get is important, like how many downloads and app launches you got last week, but it is neither immediate nor deep. You won't get live data and there is practically no information on _how_ users use your app. It's a good start, but for many, it won't be enough.
+Apple's own analytics are enabled by default, are good for user privacy, and definitely won't trigger the ATT dialog. The only problem is, we wouldn't really call them analytics: The information you get is important, like how many downloads and app launches you got last week, but it is neither immediate nor deep. You won't get live data and there is practically no information on _how_ users use your app. It's a good start, but for many, it won't be enough.
 
 ### TelemetryDeck
 
-I might be biased (spoiler: I am biased in this regard), but I think TelemetryDeck is an amazing alternative here:
+We are biased in this regard, but we think TelemetryDeck is an amazing alternative here:
 TelemetryDeck gives you completely anonymized usage data of how users use your app. This means you'll get a deep dive into usage patterns, flows, and configuration, without compromising your users' privacy.
 
 Your users will have the comfort of knowing their data is not being shared with other third parties, and they won't have to think about App Tracking Transparency dialogues. Meanwhile, you will be able to get all the information you need to improve, enhance and boost your app!

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -23,11 +23,14 @@ For our signals & parameters, we decided the prefix them with `TelemetryDeck` to
 
 ### Signals
 
--
+- `Session`: Anything related to starting, pausing, continuing, or ending a user session.
 
 ### Parameters
 
--
+- `AppContext`: The context the app runs in, such as the locale, the debug mode, or the target environment.
+- `AppInfo`: Information about the specific app build, such as version, build number, or SDKs compiled with.
+- `Device`: All about the device running the application, such as operating system, model name, or architecture.
+- `SDK`: Information about the TelemetryDeck SDK, such as the version number or supported features.
 
 {% noteinfo "No action needed" %}
 To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We have also auto-migrated any insights that were using the old names in their filters to work with the new system. This was safely achieved by replacing filters like "platform == iOS" with something like "platform == iOS OR TelemetryDeck.SystemInfo.platform == iOS" accepting both styles, ensuring you will continue to see historic data from before the transition, during the transition, and after the transition.
@@ -39,51 +42,56 @@ To make sure these changes don't affect existing customers with existing insight
 
 While doing the rename, we also noticed some missing variants of parameters that could be useful. So we added the following variants:
 
--
+- `TelemetryDeck.AppContext.region`: The regional identifier of the users country setting, e.g. `US` for United States. Used for things like date format.
+- `TelemetryDeck.AppContext.language`: The language the app is currently used in (one of the supported languages).
+- `TelemetryDeck.AppInfo.versionAndBuildNumber`: Combines the app version and build into one String, such as `1.7.1 (build 22)`.
+- `TelemetryDeck.Device.preferredLanguage`: The language most preferred by the user on this device (might not be supported by app).
+- `TelemetryDeck.Device.type`: One of `Phone`, `Tablet`, `Desktop`, `Watch`, `TV`, or `Headset`
+- `TelemetryDeck.Device.screenResolutionWidth`: The resolution width of the screen in pixel/points (whatever is most common on platform).
+- `TelemetryDeck.Device.screenResolutionHeight`: The resolution height of the screen in pixel/points (whatever is most common on platform).
+- `TelemetryDeck.Device.orientation`: One of `Portrait`, `Landscape`, or `Fixed`.
+- `TelemetryDeck.Device.timeZone`: The timezone expressed by the UTC offset, such as `UTC+0` (London), `UTC+9` (Tokyo), or `UTC-8` (San Francisco).
+- `TelemetryDeck.SDK.supportsPrefixes`: Indicates if the TelemetryDeck SDK version is already migrated to the new prefixed naming system.
 
-These could be useful to create even more accurate charts to make better informed decisions.
+These could be useful to create even more accurate charts to make better informed data-driven decisions.
 
 ## Full Migration Table
 
 Here's a full overview of all the changes we have done:
 
-
 | Old Name                   | New Name                                                |
-|----------------------------|---------------------------------------------------------|
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-| X                          | Y                                                       |
-
+| -------------------------- | ------------------------------------------------------- |
+| ActivityCreated            | Deleted (sending too many signals!)                     |
+| ActivityDestroyed          | Deleted (sending too many signals!)                     |
+| ActivityPaused             | Deleted (sending too many signals!)                     |
+| ActivityResumed            | Deleted (sending too many signals!)                     |
+| ActivitySaveInstanceState  | Deleted (sending too many signals!)                     |
+| ActivityStarted            | Deleted (sending too many signals!)                     |
+| ActivityStopped            | Deleted (sending too many signals!)                     |
+| AppBackground              | Deleted (sending too many signals!)                     |
+| AppForeground              | Deleted (sending too many signals!)                     |
+| NewSessionBegan            | TelemetryDeck.Session.started                           |
+| newSessionBegan            | TelemetryDeck.Session.started                           |
+| -------------------------- | ------------------------------------------------------- |
+| extensionIdentifier        | TelemetryDeck.AppContext.extensionIdentifier            |
+| isAppStore                 | TelemetryDeck.AppContext.isAppStore                     |
+| isDebug                    | TelemetryDeck.AppContext.isDebug                        |
+| isSimulator                | TelemetryDeck.AppContext.isSimulator                    |
+| isTestFlight               | TelemetryDeck.AppContext.isTestFlight                   |
+| locale                     | TelemetryDeck.AppContext.locale                         |
+| targetEnvironment          | TelemetryDeck.AppContext.targetEnvironment              |
+| appVersion                 | TelemetryDeck.AppInfo.version                           |
+| buildNumber                | TelemetryDeck.AppInfo.buildNumber                       |
+| dartVersion                | TelemetryDeck.AppInfo.dartVersion                       |
+| architecture               | TelemetryDeck.Device.architecture                       |
+| brand                      | TelemetryDeck.Device.brand                              |
+| modelName                  | TelemetryDeck.Device.modelName                          |
+| operatingSystem            | TelemetryDeck.Device.operatingSystem                    |
+| platform                   | TelemetryDeck.Device.platform                           |
+| majorSystemVersion         | TelemetryDeck.Device.systemMajorVersion                 |
+| majorMinorSystemVersion    | TelemetryDeck.Device.systemMajorMinorVersion            |
+| systemVersion              | TelemetryDeck.Device.systemVersion                      |
+| telemetryClientVersion     | TelemetryDeck.SDK.version                               |
 
 We hope you like these changes as much as we do!
 While we did our best to not affect any data, we might have missed something, so please contact us if you run into any issues.

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -31,7 +31,7 @@ For our signals & parameters, we decided the prefix them with `TelemetryDeck` to
 - `AppInfo`: Information about the specific app build, such as version, build number, or SDKs compiled with.
 - `Device`: All about the device running the application, such as operating system, model name, or architecture.
 - `Metric`: Information about app and device performance, such as memory (RAM), battery, or charging status.
-- `SDK`: Information about the TelemetryDeck SDK, such as the version number or supported features.
+- `SDK`: Information about the TelemetryDeck SDK, such as its name or version number.
 
 {% noteinfo "No action needed" %}
 To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We have also auto-migrated any insights that were using the old names in their filters to work with the new system. This was safely achieved by replacing filters like "platform == iOS" with something like "platform == iOS OR TelemetryDeck.SystemInfo.platform == iOS" accepting both styles, ensuring you will continue to see historic data from before the transition, during the transition, and after the transition.
@@ -52,7 +52,8 @@ While doing the rename, we also noticed some missing variants of parameters that
 - `TelemetryDeck.Device.screenResolutionHeight`: The resolution height of the screen in pixel/points (whatever is most common on platform).
 - `TelemetryDeck.Device.orientation`: One of `Portrait`, `Landscape`, or `Fixed`.
 - `TelemetryDeck.Device.timeZone`: The timezone expressed by the UTC offset, such as `UTC+0` (London), `UTC+9` (Tokyo), or `UTC-8` (San Francisco).
-- `TelemetryDeck.SDK.supportsPrefixes`: Indicates if the TelemetryDeck SDK version is already migrated to the new prefixed naming system.
+- `TelemetryDeck.SDK.name`: Just the TelemetryDeck SDK's name that was used to send the signal, such as `SwiftSDK`, `KotlinSDK`, or `FlutterSDK`.
+- `TelemetryDeck.SDK.version`: Just TelemetryDeck SDK's version that was used to send the signal, such as `1.5.1`.
 
 These could be useful to create even more accurate charts to make better informed data-driven decisions.
 
@@ -92,7 +93,7 @@ Here's a full overview of all the changes we have done:
 | majorSystemVersion         | TelemetryDeck.Device.systemMajorVersion                 |
 | majorMinorSystemVersion    | TelemetryDeck.Device.systemMajorMinorVersion            |
 | systemVersion              | TelemetryDeck.Device.systemVersion                      |
-| telemetryClientVersion     | TelemetryDeck.SDK.version                               |
+| telemetryClientVersion     | TelemetryDeck.SDK.nameAndVersion                        |
 
 We hope you like these changes as much as we do!
 While we did our best to not affect any data, we might have missed something, so please contact us if you run into any issues.

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -1,0 +1,89 @@
+---
+title: TelemetryDeck's Grand Rename
+tags: setup
+description: To avoid ambiguity and clean up things for the long term, we have decided to rename quite a few things in all the TelemetryDeck SDKs. We have laid out a migration path, here's all you need to know about it.
+lead: To avoid ambiguity and clean up things for the long term, we have decided to rename quite a few things in all the TelemetryDeck SDKs. We have laid out a migration path, here's all you need to know about it.
+---
+
+## Motivation
+
+When we started TelemetryDeck, it was clearly scoped to the iOS platform and we naturally started with a Swift client first. To get to speed quickly like one does, we decided to send a defualt signal & a bunch of parameters automatically. To keep things simple, we named the signal `newSessionBegan` the parameters `appVersion` and `locale`, for example.
+
+But over time, we added more and more SDKs and now we have 5, but only 4 of them are also called "SDK": The initial Swift client was simply called "SwiftClient". We used the platform-specific terminology for things, leading to different names in some places. And we also learned the power of grouping signal names and event parameters as documented in our [naming guideline](https://telemetrydeck.com/docs/articles/signal-type-naming/). Because we sort everything alphabetically in our UI, it's a natural help in finding things more quickly if related things have the same prefix. Also, users could accidentally use the same signal or parameter name and override ours, causing confusion in the insight data.
+
+After more than 3 years working on TelemetryDeck, we think it's about time to streamline things for a more clear long-term future.
+
+## Consistency, Longevity, and Clarity
+
+Our main goals with our new naming scheme were to be internally consistent, but at the same time make sure the names are abstract enough to work flexibly for changes to come in the foreseeable future. Too abstract names can be confusing and cumbersome, so we additionally strived for clarity.
+
+The most obvious change was to rename our Swift repository from "SwiftClient" to "SwiftSDK". Thanks to GitHub redirections, this change should have no effect on our existing customers, but long term, it should make things more consistent. 🎉
+
+For our signals & parameters, we decided the prefix them with `TelemetryDeck` to make the source clear and avoid amgiguity. Additionally, we analyzed all the signals and parameters we currently send and future ones we have in our roadmap and grouped them as follows:
+
+### Signals
+
+-
+
+### Parameters
+
+-
+
+{% noteinfo "No action needed" %}
+To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We have also auto-migrated any insights that were using the old names in their filters to work with the new system. This was safely achieved by replacing filters like "platform == iOS" with something like "platform == iOS OR TelemetryDeck.SystemInfo.platform == iOS" accepting both styles, ensuring you will continue to see historic data from before the transition, during the transition, and after the transition.
+{% endnoteinfo %}
+
+<!-- Discussion: What about Top-N insights that use a parameter like "appVersion" which got renamed to "TelemetryDeck.SystemInfo.appVersion"? -->
+
+## Filling the Gaps
+
+While doing the rename, we also noticed some missing variants of parameters that could be useful. So we added the following variants:
+
+-
+
+These could be useful to create even more accurate charts to make better informed decisions.
+
+## Full Migration Table
+
+Here's a full overview of all the changes we have done:
+
+
+| Old Name                   | New Name                                                |
+|----------------------------|---------------------------------------------------------|
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+| X                          | Y                                                       |
+
+
+We hope you like these changes as much as we do!
+While we did our best to not affect any data, we might have missed something, so please contact us if you run into any issues.

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -33,11 +33,9 @@ For our signals & parameters, we decided the prefix them with `TelemetryDeck` to
 - `Metric`: Information about app and device performance, such as memory (RAM), battery, or charging status.
 - `SDK`: Information about the TelemetryDeck SDK, such as its name or version number.
 
-{% noteinfo "No action needed" %}
-To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We have also auto-migrated any insights that were using the old names in their filters to work with the new system. This was safely achieved by replacing filters like "platform == iOS" with something like "platform == iOS OR TelemetryDeck.SystemInfo.platform == iOS" accepting both styles, ensuring you will continue to see historic data from before the transition, during the transition, and after the transition.
+{% noteinfo "No immediate action needed" %}
+To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We recommend using the new ones for any new insights you create and will elaborate ways to support our users in transitioning any existing insights before we fully migrate.
 {% endnoteinfo %}
-
-<!-- Discussion: What about Top-N insights that use a parameter like "appVersion" which got renamed to "TelemetryDeck.SystemInfo.appVersion"? -->
 
 ## Filling the Gaps
 

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -30,6 +30,7 @@ For our signals & parameters, we decided the prefix them with `TelemetryDeck` to
 - `AppContext`: The context the app runs in, such as the locale, the debug mode, or the target environment.
 - `AppInfo`: Information about the specific app build, such as version, build number, or SDKs compiled with.
 - `Device`: All about the device running the application, such as operating system, model name, or architecture.
+- `Metric`: Information about app and device performance, such as memory (RAM), battery, or charging status.
 - `SDK`: Information about the TelemetryDeck SDK, such as the version number or supported features.
 
 {% noteinfo "No action needed" %}

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -47,7 +47,6 @@ While doing the rename, we also noticed some missing variants of parameters that
 - `TelemetryDeck.AppContext.language`: The language the app is currently used in (one of the supported languages).
 - `TelemetryDeck.AppInfo.versionAndBuildNumber`: Combines the app version and build into one String, such as `1.7.1 (build 22)`.
 - `TelemetryDeck.Device.preferredLanguage`: The language most preferred by the user on this device (might not be supported by app).
-- `TelemetryDeck.Device.type`: One of `Phone`, `Tablet`, `Desktop`, `Watch`, `TV`, or `Headset`
 - `TelemetryDeck.Device.screenResolutionWidth`: The resolution width of the screen in pixel/points (whatever is most common on platform).
 - `TelemetryDeck.Device.screenResolutionHeight`: The resolution height of the screen in pixel/points (whatever is most common on platform).
 - `TelemetryDeck.Device.orientation`: One of `Portrait`, `Landscape`, or `Fixed`.

--- a/articles/grand-rename.md
+++ b/articles/grand-rename.md
@@ -7,9 +7,9 @@ lead: To avoid ambiguity and clean up things for the long term, we have decided 
 
 ## Motivation
 
-When we started TelemetryDeck, it was clearly scoped to the iOS platform and we naturally started with a Swift client first. To get to speed quickly like one does, we decided to send a defualt signal & a bunch of parameters automatically. To keep things simple, we named the signal `newSessionBegan` the parameters `appVersion` and `locale`, for example.
+When we started TelemetryDeck, it was clearly scoped to the iOS platform and we naturally started with a Swift client first. To get to speed quickly like one does, we decided to send a defualt signal & a bunch of parameters automatically. To keep things simple, we named the signal `newSessionBegan` and the parameters `appVersion` and `locale`, for example.
 
-But over time, we added more and more SDKs and now we have 5, but only 4 of them are also called "SDK": The initial Swift client was simply called "SwiftClient". We used the platform-specific terminology for things, leading to different names in some places. And we also learned the power of grouping signal names and event parameters as documented in our [naming guideline](https://telemetrydeck.com/docs/articles/signal-type-naming/). Because we sort everything alphabetically in our UI, it's a natural help in finding things more quickly if related things have the same prefix. Also, users could accidentally use the same signal or parameter name and override ours, causing confusion in the insight data.
+But over time, we added more and more SDKs and now we have 5, but only 4 of them are also called "SDK": The initial Swift client was simply called "SwiftClient". We also used the platform-specific terminology for things, leading to different names in some places. And we also learned the power of grouping signal names and event parameters as documented in our [naming guideline](https://telemetrydeck.com/docs/articles/signal-type-naming/). Because we sort everything alphabetically in our UI, it's a natural help in finding things more quickly if related things have the same prefix. Also, users could accidentally use the same signal or parameter name and override ours, causing confusion in the insight data.
 
 After more than 3 years working on TelemetryDeck, we think it's about time to streamline things for a more clear long-term future.
 
@@ -19,7 +19,7 @@ Our main goals with our new naming scheme were to be internally consistent, but 
 
 The most obvious change was to rename our Swift repository from "SwiftClient" to "SwiftSDK". Thanks to GitHub redirections, this change should have no effect on our existing customers, but long term, it should make things more consistent. 🎉
 
-For our signals & parameters, we decided the prefix them with `TelemetryDeck` to make the source clear and avoid amgiguity. Additionally, we analyzed all the signals and parameters we currently send and future ones we have in our roadmap and grouped them as follows:
+For our signals & parameters, we decided to prefix them with `TelemetryDeck` to make the source clear and avoid ambiguity. Additionally, we analyzed all the signals and parameters we currently send and some future ones we have in our roadmap and grouped them as follows:
 
 ### Signals
 
@@ -27,11 +27,12 @@ For our signals & parameters, we decided the prefix them with `TelemetryDeck` to
 
 ### Parameters
 
-- `AppContext`: The context the app runs in, such as the locale, the debug mode, or the target environment.
 - `AppInfo`: Information about the specific app build, such as version, build number, or SDKs compiled with.
 - `Device`: All about the device running the application, such as operating system, model name, or architecture.
 - `Metric`: Information about app and device performance, such as memory (RAM), battery, or charging status.
+- `RunContext`: The context the app runs in, such as simulator, debug mode, or target environment.
 - `SDK`: Information about the TelemetryDeck SDK, such as its name or version number.
+- `UserPreference`: Any choices the user made to express personal preferences, such as language & region.
 
 {% noteinfo "No immediate action needed" %}
 To make sure these changes don't affect existing customers with existing insights anytime soon, we decided to keep sending the old names for a transition period of at least 1 year while also sending the new ones. We recommend using the new ones for any new insights you create and will elaborate ways to support our users in transitioning any existing insights before we fully migrate.
@@ -41,16 +42,16 @@ To make sure these changes don't affect existing customers with existing insight
 
 While doing the rename, we also noticed some missing variants of parameters that could be useful. So we added the following variants:
 
-- `TelemetryDeck.AppContext.region`: The regional identifier of the users country setting, e.g. `US` for United States. Used for things like date format.
-- `TelemetryDeck.AppContext.language`: The language the app is currently used in (one of the supported languages).
 - `TelemetryDeck.AppInfo.versionAndBuildNumber`: Combines the app version and build into one String, such as `1.7.1 (build 22)`.
-- `TelemetryDeck.Device.preferredLanguage`: The language most preferred by the user on this device (might not be supported by app).
+- `TelemetryDeck.Device.orientation`: One of `Portrait`, `Landscape`, or `Fixed`.
 - `TelemetryDeck.Device.screenResolutionWidth`: The resolution width of the screen in pixel/points (whatever is most common on platform).
 - `TelemetryDeck.Device.screenResolutionHeight`: The resolution height of the screen in pixel/points (whatever is most common on platform).
-- `TelemetryDeck.Device.orientation`: One of `Portrait`, `Landscape`, or `Fixed`.
 - `TelemetryDeck.Device.timeZone`: The timezone expressed by the UTC offset, such as `UTC+0` (London), `UTC+9` (Tokyo), or `UTC-8` (San Francisco).
+- `TelemetryDeck.RunContext.language`: The language the app is currently used in (one of the supported languages).
 - `TelemetryDeck.SDK.name`: Just the TelemetryDeck SDK's name that was used to send the signal, such as `SwiftSDK`, `KotlinSDK`, or `FlutterSDK`.
 - `TelemetryDeck.SDK.version`: Just TelemetryDeck SDK's version that was used to send the signal, such as `1.5.1`.
+- `TelemetryDeck.UserPreference.region`: The regional identifier of the users country setting, e.g. `US` for United States.
+- `TelemetryDeck.UserPreference.language`: The language most preferred by the user on this device (might not be supported by app).
 
 These could be useful to create even more accurate charts to make better informed data-driven decisions.
 
@@ -60,28 +61,21 @@ Here's a full overview of all the changes we have done:
 
 | Old Name                   | New Name                                                |
 | -------------------------- | ------------------------------------------------------- |
-| ActivityCreated            | Deleted (sending too many signals!)                     |
-| ActivityDestroyed          | Deleted (sending too many signals!)                     |
-| ActivityPaused             | Deleted (sending too many signals!)                     |
-| ActivityResumed            | Deleted (sending too many signals!)                     |
-| ActivitySaveInstanceState  | Deleted (sending too many signals!)                     |
-| ActivityStarted            | Deleted (sending too many signals!)                     |
-| ActivityStopped            | Deleted (sending too many signals!)                     |
-| AppBackground              | Deleted (sending too many signals!)                     |
-| AppForeground              | Deleted (sending too many signals!)                     |
+| ActivityCreated            | Deleted (was sending too many signals)                  |
+| ActivityDestroyed          | Deleted (was sending too many signals)                  |
+| ActivityPaused             | Deleted (was sending too many signals)                  |
+| ActivityResumed            | Deleted (was sending too many signals)                  |
+| ActivitySaveInstanceState  | Deleted (was sending too many signals)                  |
+| ActivityStarted            | Deleted (was sending too many signals)                  |
+| ActivityStopped            | Deleted (was sending too many signals)                  |
+| AppBackground              | Deleted (was sending too many signals)                  |
+| AppForeground              | Deleted (was sending too many signals)                  |
 | NewSessionBegan            | TelemetryDeck.Session.started                           |
 | newSessionBegan            | TelemetryDeck.Session.started                           |
 | -------------------------- | ------------------------------------------------------- |
-| extensionIdentifier        | TelemetryDeck.AppContext.extensionIdentifier            |
-| isAppStore                 | TelemetryDeck.AppContext.isAppStore                     |
-| isDebug                    | TelemetryDeck.AppContext.isDebug                        |
-| isSimulator                | TelemetryDeck.AppContext.isSimulator                    |
-| isTestFlight               | TelemetryDeck.AppContext.isTestFlight                   |
-| locale                     | TelemetryDeck.AppContext.locale                         |
-| targetEnvironment          | TelemetryDeck.AppContext.targetEnvironment              |
-| appVersion                 | TelemetryDeck.AppInfo.version                           |
 | buildNumber                | TelemetryDeck.AppInfo.buildNumber                       |
 | dartVersion                | TelemetryDeck.AppInfo.dartVersion                       |
+| appVersion                 | TelemetryDeck.AppInfo.version                           |
 | architecture               | TelemetryDeck.Device.architecture                       |
 | brand                      | TelemetryDeck.Device.brand                              |
 | modelName                  | TelemetryDeck.Device.modelName                          |
@@ -90,6 +84,13 @@ Here's a full overview of all the changes we have done:
 | majorSystemVersion         | TelemetryDeck.Device.systemMajorVersion                 |
 | majorMinorSystemVersion    | TelemetryDeck.Device.systemMajorMinorVersion            |
 | systemVersion              | TelemetryDeck.Device.systemVersion                      |
+| extensionIdentifier        | TelemetryDeck.RunContext.extensionIdentifier            |
+| isAppStore                 | TelemetryDeck.RunContext.isAppStore                     |
+| isDebug                    | TelemetryDeck.RunContext.isDebug                        |
+| isSimulator                | TelemetryDeck.RunContext.isSimulator                    |
+| isTestFlight               | TelemetryDeck.RunContext.isTestFlight                   |
+| locale                     | TelemetryDeck.RunContext.locale                         |
+| targetEnvironment          | TelemetryDeck.RunContext.targetEnvironment              |
 | telemetryClientVersion     | TelemetryDeck.SDK.nameAndVersion                        |
 
 We hope you like these changes as much as we do!

--- a/articles/signal-type-naming.md
+++ b/articles/signal-type-naming.md
@@ -31,25 +31,27 @@ What many of our customers do (and we ourselves internally as well) is using a d
 
 Here are some examples:
 
-- `InsightEditor.MetaEditor.SaveInsight`
-- `Main.AppLaunched`
-- `Preferences.ErrorModal.Shown`
+- `InsightEditor.MetaEditor.saveInsight`
+- `Main.appLaunched`
+- `Preferences.ErrorModal.shown`
 
 We recommend you don’t make the paths too specific or deeper than, say, 3 levels. Otherwise, you’ll run into annoying mismatches when you move a feature around but can’t really rename the insight type to match.
 
+Note that we like to use UpperCamelCase for the prefix components but lowerCamelCase for the last component because that matches how calls are made in most programming languages, inluding Swift and Kotlin. The convention there is that types names are uppercased but functions and parameters are lowercased. We feel this style looks more natural alongside other code, but you can of course find your own style!
+
 ## Distinguishing between views, actions and events
 
-If you want to distinguish between views, actions and events, or just views and actions, you can add that to the type, such as `InsightEditor.MetaEditor.actions.SaveInsight`. However, I personally don’t get much value from that. Instead, I usually annotate types implicitly using grammar:
+If you want to distinguish between views, actions and events, or just views and actions, you can add that to the type, such as `InsightEditor.MetaEditor.Actions.saveInsight`. However, I personally don’t get much value from that. Instead, I usually annotate types implicitly using grammar:
 
 1. Present tense compound verbs are actions:
 
-- `InsightEditor.MetaEditor.SaveInsight`
-- `Preferences.SyncNow`
+- `InsightEditor.MetaEditor.saveInsight`
+- `Preferences.syncNow`
 
 2. Anything in past tense is a view or an event:
 
-- `InsightEditor.Appeared`
-- `Main.AppLaunched`
-- `Preferences.ErrorModal.Shown`
+- `InsightEditor.appeared`
+- `Main.appLaunched`
+- `Preferences.ErrorModal.shown`
 
 Don’t be afraid to play around a bit and find out what works best for you!

--- a/articles/signal-type-naming.md
+++ b/articles/signal-type-naming.md
@@ -6,14 +6,9 @@ lead: Should you give your signal types a simple name, or use a more complex nam
 ---
 
 When you send a signal, you'll always have to tell TelemetryDeck what **type** of signal you want to send. Type is just a
-String, so in theory you could add anything in there. Your type could be `asfdgllahsavhaligha`, or `This sentence no verb` or even `🤖`, or
-`daniel-is-a-poopy-butt`.
+String, so in theory you could add anything in there. Your type could be `asfdgllahsavhaligha`, or `This sentence no verb` or even `🤖`.
 
-{% noteinfo "Important note by Daniel" %}
-
-Please don't do that last one, though. It's not very helpful, and studies have shown that I am not in fact a poopy butt.
-
-{% endnoteinfo %}
+But we recommend a different style to keep things clear and easy to find.
 
 ## Single word types
 
@@ -37,11 +32,11 @@ Here are some examples:
 
 We recommend you don’t make the paths too specific or deeper than, say, 3 levels. Otherwise, you’ll run into annoying mismatches when you move a feature around but can’t really rename the insight type to match.
 
-Note that we like to use UpperCamelCase for the prefix components but lowerCamelCase for the last component because that matches how calls are made in most programming languages, inluding Swift and Kotlin. The convention there is that types names are uppercased but functions and parameters are lowercased. We feel this style looks more natural alongside other code, but you can of course find your own style!
+We prefer to use UpperCamelCase for the prefix components but lowerCamelCase for the last component because that matches how calls are made in most programming languages, inluding Swift and Kotlin. The convention there is that type names are uppercased but functions and parameters are lowercased. We feel this style looks more natural alongside other code, but you can of course use a different style, just be consistent with it!
 
 ## Distinguishing between views, actions and events
 
-If you want to distinguish between views, actions and events, or just views and actions, you can add that to the type, such as `InsightEditor.MetaEditor.Actions.saveInsight`. However, I personally don’t get much value from that. Instead, I usually annotate types implicitly using grammar:
+If you want to distinguish between views, actions and events, or just views and actions, you can add that to the type, such as `InsightEditor.MetaEditor.Actions.saveInsight`. However, we don’t get much value from that. Instead, we usually annotate types implicitly using grammar:
 
 1. Present tense compound verbs are actions:
 

--- a/articles/telemetry-client.md
+++ b/articles/telemetry-client.md
@@ -16,18 +16,18 @@ See the [Swift Guide](/docs/guides/swift-setup/) on how to set up your app to us
 
 ## Initialization
 
-Init the TelemetryDeck Manager at app startup, so it knows your App ID (you can retrieve the App ID in the TelemetryDeck Viewer app, under App Settings)
+Init the TelemetryDeck at app startup, so it knows your App ID (you can retrieve the App ID in the TelemetryDeck Viewer app, under App Settings)
 
 ```swift
-let configuration = TelemetryManagerConfiguration(appID: "<YOUR-APP-ID>")
-TelemetryManager.initialize(with: configuration)
+let config = TelemetryDeck.Config(appID: "<YOUR-APP-ID>")
+TelemetryDeck.initialize(config: config)
 ```
 
 For example, if you're building a scene based app, in the `init()` function for your `App`:
 
 ```swift
 import SwiftUI
-import TelemetryClient
+import TelemetryDeck
 
 @main
 struct TelemetryTestApp: App {
@@ -41,8 +41,8 @@ struct TelemetryTestApp: App {
         // Note: Do not add this code to `WindowGroup.onAppear`, which will be called
         //       *after* your window has been initialized, and might lead to out initialization
         //       occurring too late.
-        let configuration = TelemetryManagerConfiguration(appID: "<YOUR-APP-ID>")
-        TelemetryManager.initialize(with: configuration)
+        let config = TelemetryDeck.Config(appID: "<YOUR-APP-ID>")
+        TelemetryDeck.initialize(config: config)
     }
 }
 ```
@@ -52,48 +52,66 @@ struct TelemetryTestApp: App {
 Once you've included the TelemetryDeck Swift Client, send signals like so:
 
 ```swift
-TelemetryManager.send("appLaunchedRegularly")
+TelemetryDeck.signal"appLaunchedRegularly")
 ```
 
-TelemetryDeck Manager will create a user identifier for your user that is specific to app installation and device. If you have a better user identifier available, you can use that instead: (the identifier will be hashed before sending it)
+TelemetryDeck will create a user identifier for your user that is specific to app installation and device. If you have a better user identifier available, you can use that instead: (the identifier will be hashed before sending it)
 
 ```swift
 let email = MyConfiguration.User.Email
-TelemetryManager.send("userLoggedIn", for: email)
+TelemetryDeck.signal"userLoggedIn", customUserID: email)
 ```
 
 <div class="alert alert-secondary" role="alert">
 <h4 class="alert-heading">Note on User Identifiers on Mac</h4>
-<p><small>If you are writing a Mac App, TelemetryDeck Manager can not create a unique user identifier, and will instead default to a concatenation of your OS Version and App Build number, which is not exactly unique, so user counting will be less accurate.</small></p>
+<p><small>If you are writing a Mac App, TelemetryDeck can not create a unique user identifier, and will instead default to a concatenation of your OS Version and App Build number, which is not exactly unique, so user counting will be less accurate.</small></p>
 
-<p><small>We therefore strongly recommend to either use a unique identifier for your users, such as an email address, or to generate and store a `UUID().uuidString`, for example in `UserDefaults`, and always pass that to TelemetryDeck Manager as User ID.</small></p>
+<p><small>We therefore strongly recommend to either use a unique identifier for your users, such as an email address, or to generate and store a `UUID().uuidString`, for example in `UserDefaults`, and always pass that to TelemetryDeck as User ID.</small></p>
 
-<p><small>The reason why TelemetryDeck Manager can't do that itself is that it feels like crossing a line if this simple tool would generate IDs itself and write those to a directory on disk. We feel that this is not expected behaviour for a privacy-first analytics package.</small></p>
+<p><small>The reason why TelemetryDeck can't do that itself is that it feels like crossing a line if this simple tool would generate IDs itself and write those to a directory on disk. We feel that this is not expected behaviour for a privacy-first analytics package.</small></p>
 
 </div>
 
 ## Payload Data
 
-You can also send additional payload data with each signal:
+You can also send additional parameters with each signal:
 
 ```swift
-TelemetryManager.send("databaseUpdated", with: ["numberOfDatabaseEntries": "3831"])
+TelemetryDeck.signal"databaseUpdated", parameters: ["numberOfDatabaseEntries": "3831"])
 ```
 
-TelemetryDeck Manager will automatically send a base payload with these keys:
+TelemetryDeck will automatically send base parameters with these keys:
 
-- `platform`
-- `systemVersion`
-- `appVersion`
-- `buildNumber`
-- `isSimulator`
-- `isTestFlight`
-- `isAppStore`
-- `modelName`
-- `architecture`
-- `operatingSystem`
-- `targetEnvironment`
+- `TelemetryDeck.AppInfo.buildNumber`
+- `TelemetryDeck.AppInfo.dartVersion`
+- `TelemetryDeck.AppInfo.version`
+- `TelemetryDeck.AppInfo.versionAndBuildNumber`
+- `TelemetryDeck.Device.architecture`
+- `TelemetryDeck.Device.brand`
+- `TelemetryDeck.Device.modelName`
+- `TelemetryDeck.Device.operatingSystem`
+- `TelemetryDeck.Device.orientation`
+- `TelemetryDeck.Device.platform`
+- `TelemetryDeck.Device.screenResolutionWidth`
+- `TelemetryDeck.Device.screenResolutionHeight`
+- `TelemetryDeck.Device.systemMajorVersion`
+- `TelemetryDeck.Device.systemMajorMinorVersion`
+- `TelemetryDeck.Device.systemVersion`
+- `TelemetryDeck.Device.timeZone`
+- `TelemetryDeck.RunContext.extensionIdentifier`
+- `TelemetryDeck.RunContext.isAppStore`
+- `TelemetryDeck.RunContext.isDebug`
+- `TelemetryDeck.RunContext.isSimulator`
+- `TelemetryDeck.RunContext.isTestFlight`
+- `TelemetryDeck.RunContext.language`
+- `TelemetryDeck.RunContext.locale`
+- `TelemetryDeck.RunContext.targetEnvironment`
+- `TelemetryDeck.SDK.name`
+- `TelemetryDeck.SDK.nameAndVersion`
+- `TelemetryDeck.SDK.version`
+- `TelemetryDeck.UserPreference.region`
+- `TelemetryDeck.UserPreference.language`
 
 ## Debug Mode
 
-TelemetryDeck Manager will _not_ send any signals if you are in `DEBUG` Mode. You can override this by setting `configuration.telemetryAllowDebugBuilds = true` on your `TelemetryManagerConfiguration` instance.
+TelemetryDeck will _not_ send any signals if you are in `DEBUG` Mode. You can override this by setting `configuration.telemetryAllowDebugBuilds = true` on your `TelemetryDeck.Configuration` instance.

--- a/articles/telemetry-client.md
+++ b/articles/telemetry-client.md
@@ -66,9 +66,9 @@ TelemetryManager.send("userLoggedIn", for: email)
 <h4 class="alert-heading">Note on User Identifiers on Mac</h4>
 <p><small>If you are writing a Mac App, TelemetryDeck Manager can not create a unique user identifier, and will instead default to a concatenation of your OS Version and App Build number, which is not exactly unique, so user counting will be less accurate.</small></p>
 
-<p><small>I therefore strongly recommend to either use a unique identifier for your users, such as an email address, or to generate and store a `UUID().uuidString`, for example in `UserDefaults`, and always pass that to TelemetryDeck Manager as User ID.</small></p>
+<p><small>We therefore strongly recommend to either use a unique identifier for your users, such as an email address, or to generate and store a `UUID().uuidString`, for example in `UserDefaults`, and always pass that to TelemetryDeck Manager as User ID.</small></p>
 
-<p><small>The reason why TelemetryDeck Manager can't do that itself is that it feels like crossing a line if this simple tool would generate IDs itself and write those to a directory on disk. I feel that this is not expected behaviour for a privacy-first analytics package.</small></p>
+<p><small>The reason why TelemetryDeck Manager can't do that itself is that it feels like crossing a line if this simple tool would generate IDs itself and write those to a directory on disk. We feel that this is not expected behaviour for a privacy-first analytics package.</small></p>
 
 </div>
 

--- a/guides/objective-c-setup.md
+++ b/guides/objective-c-setup.md
@@ -22,8 +22,8 @@ The TelemetryDeck Swift package uses Swift Package Manager.
 
 1. Open Xcode and navigate to the project you want to add TelemetryDeck to.
 1. In the menu, select <kbd>File</kbd> -> <kbd>Add Packages...</kbd>. This will open the Swift Package Manager view.
-1. Paste `https://github.com/TelemetryDeck/SwiftClient` into the search field.
-1. Select the `SwiftClient` package that appears in the list
+1. Paste `https://github.com/TelemetryDeck/SwiftSDK` into the search field.
+1. Select the `SwiftSDK` package that appears in the list
 1. Set the <kbd>Dependency Rule</kbd> to <kbd>Up to Next Major Version</kbd>.
 1. Click <kbd>Add Package</kbd>.
 
@@ -33,7 +33,7 @@ This will include the TelemetryDeck Swift Client into your app by downloading th
 
 ## Including the package in your target
 
-Xcode will ask you to link the package with your target in the next screen, titles <kbd>Choose Package Products for SwiftClient</kbd>. Select the `TelemetryClient` library and click <kbd>Add Package</kbd>.
+Xcode will ask you to link the package with your target in the next screen, titles <kbd>Choose Package Products for SwiftSDK</kbd>. Select the `TelemetryClient` library and click <kbd>Add Package</kbd>.
 
 {% noteinfo "Link Library with more than one Target" %}
 
@@ -88,7 +88,7 @@ Signals represent an **event** or a **view** that happened in your app, which is
 See the [Signals Reference](/docs/api/signals-reference/) for more information about how you can effectively use Signals.
 {% endnoteinfo %}
 
-See the [TelemetryDeck package's `README.md` file](https://github.com/TelemetryDeck/SwiftClient/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to your app delegate and below the initialization add this line:
+See the [TelemetryDeck package's `README.md` file](https://github.com/TelemetryDeck/SwiftSDK/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to your app delegate and below the initialization add this line:
 
 ```objc
 [TelemetryManager send:@"applicationDidFinishLaunching"];

--- a/guides/swift-setup.md
+++ b/guides/swift-setup.md
@@ -34,7 +34,7 @@ This will include the TelemetryDeck Swift Client into your app by downloading th
 
 ## Including the package in your target
 
-Xcode will ask you to link the package with your target in the next screen, titles <kbd>Choose Package Products for SwiftSDK</kbd>. Select the `TelemetryDeck` library and click <kbd>Add Package</kbd>.
+Xcode will ask you to link the package with your target in the next screen, titled <kbd>Choose Package Products for SwiftSDK</kbd>. Select the `TelemetryDeck` library and click <kbd>Add Package</kbd>.
 
 {% noteinfo "Link Library with more than one Target" %}
 
@@ -63,7 +63,7 @@ For Scene-based SwiftUI applications, we recommend adding the initialization to 
 import SwiftUI
 
 @main
-struct Example_AppApp: App {
+struct YourAppNameApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -74,7 +74,7 @@ struct Example_AppApp: App {
 
 This is the entry point to your app. Now let's add the initialization here.
 
-Import the TelemetryDeck Package by adding `import TelemetryDeck`. Then add an `init()` method to your App struct that creates a `TelemetryDeck.Config` instance and hands it to the `TelemetryDeck`, using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore, you can get it at any time from the TelemetryDeck Dashboard.
+Import the TelemetryDeck Package by adding `import TelemetryDeck`. Then add an `init()` method to your App struct that creates a `TelemetryDeck.Config` instance and hands it to `TelemetryDeck.initialize(config:)`, using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore, you can get it at any time from the TelemetryDeck Dashboard.
 
 Your code should now look like this:
 
@@ -83,23 +83,27 @@ import SwiftUI
 import TelemetryDeck
 
 @main
-struct Example_AppApp: App {
+struct YourAppNameApp: App {
+    init() {
+        let config = TelemetryDeck.Config(appID: "YOUR-APP-ID")
+        TelemetryDeck.initialize(config: config)
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
     }
-
-    init() {
-        let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
-        TelemetryDeck.initialize(config: config)
-    }
 }
 ```
 
-If you already have an `init()` method, add the two lines to its end.
+If you prefer to have it on a single line, you can also write:
 
-Your app is now ready. You can skip the AppDelegate part if you're using SwiftUI and SceneKit.
+```swift
+TelemetryDeck.initialize(config: .init(appID: "YOUR-APP-ID"))
+```
+
+Your app is now ready to use TelemetryDeck. You can skip the next section which explains setup for UIKit-based apps.
 
 ### Initialization in an AppDelegate based app
 
@@ -131,7 +135,7 @@ import TelemetryDeck
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
+        let config = TelemetryDeck.Config(appID: "YOUR-APP-ID")
         TelemetryDeck.initialize(config: config)
 
         return true
@@ -139,8 +143,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // ...
 }
 ```
-
-If you already have code in this function, add the two new lines to the end.
 
 You are now ready to send signals!
 
@@ -152,47 +154,53 @@ Let's send a signal to show the app has launched correctly.
 
 Signals are an indication that **an event** happened in your app, which is used by a **user**. Signals consist of these parts:
 
-- **Signal Type** – A string that indicates which kind of event happened
-- **User Identifer** – A string that identifies your user
-- **Metadata Payload** – A dictionary of additional data about your app or the event triggering the signal
+- **Signal Name** – A string that indicates which kind of event happened
+- **User Identifer** – A string that identifies your user (we auto-generate one for you)
+- **Optional Parameters** – A dictionary of additional data about your app or the event triggering the signal
 
 See the [Signals Reference](/docs/api/signals-reference/) for more information about how you can effectively use Signals.
 {% endnoteinfo %}
 
-{% notewarning "When running from Xcode, you're sending testing signals" %}
+{% notewarning "When running from Xcode, you're sending test signals" %}
 
-If your app is built in `DEBUG` configuration (i.e. running from Xcode), your signals will be tagged as **Testing Signals**, meaning that you can easily filter them out later. You'll see them show up in the TelemetryDeck Dashboard when it is set to **Test Mode**.
+If your app is built in `DEBUG` configuration (i.e. running from Xcode), your signals will be tagged as **Test Signals**, meaning that you can easily filter them out later. You'll see them show up in the TelemetryDeck Dashboard when the **Test Mode** toggle in the sidebar is turned on.
 {% endnotewarning %}
 
-See the [TelemetryDeck SDK's `README.md` file](https://github.com/TelemetryDeck/SwiftSDK/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to the place where you just added the initialization, and directly below add this line:
+See the [TelemetryDeck SDK's `README.md` file](https://github.com/TelemetryDeck/SwiftSDK/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to the place where you just added the initialization, and directly below add another line:
 
 ```swift
-let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
+let config = TelemetryDeck.Config(appID: "YOUR-APP-ID")
 TelemetryDeck.initialize(config: config)
 
-TelemetryDeck.signal("App.didFinishLaunching")
+TelemetryDeck.signal("App.launched")
 ```
 
-And done. This is all you need to send a signal. You do not need to keep an instance of TelemetryDeck and hand it around, just call the `send` function on the class directly. If you want to add a custom user identifer or metadata payload, add them to the function call like this:
+And done. This is all you need to send a signal. You do not need to keep an instance of TelemetryDeck and hand it around, just call the static `signal` function on the class directly. If you want to add a custom user identifer or metadata payload, add them to the function call like this:
 
 ```swift
 TelemetryDeck.signal(
-    "App.didFinishLaunching",
+    "App.launched",
     parameters: [
         "numberOfTimesPizzaModeHasActivated": "\(dataStore.pizzaMode.count)",
         "pizzaCheeseMode": "\(dataStore.pizzaCheeseMode)"
     ],
-    customUserID: "my very cool user"
+    customUserID: "my.very.cool@user.com"
 )
 ```
 
-And you're done! You are now sending signals to the TelemetryDeck server.
+{% noteinfo "Privacy Note" %}
+The value you pass to `customUserID` will be automatically hashed before being sent to our servers to protect the users privacy. This does not happen for the values in `parameters` though, so hash yourself where needed.
+{% endnoteinfo %}
+
+And you're done! You are now sending signals to the TelemetryDeck server. 🎉
+
+Run your app and confirm that your first signal arrived in the "Recent Signals" tab on TelemetryDeck. Don't forget to turn on "Test Mode" to see signals sent in debug builds!
 
 ## Fill out Apple's app privacy details
 
-Last thing you need to do before you can send signals is going through Apple's privacy details. This informs your users about what data is collected, and how it is collected.
+Something you need to do before you can upload your app to the App Store is going through Apple's privacy details on App Store Connect. This informs your users about what data is collected, and how it is collected.
 
-Also TelemetryDeck is privacy friendly, and we only handle not personally identifiable information, you still need to click through the privacy details.
+Although TelemetryDeck is privacy friendly, as we only handle not personally identifiable information, you still need to click through the privacy details.
 
 We have a [handy guide](/docs/articles/apple-app-privacy/) where we go over each step that is required.
 
@@ -202,6 +210,6 @@ You don't need to update your privacy policy, [but we recommend you do it anyway
 
 ## You're all set!
 
-You can now send signals! Don't overdo it in the beginning. It's okay if you only send **one** signal, named `applicationDidFinishLaunching` in the beginning. This will already give you number of users, number of launches, retention… a lot!
+You can now send signals! Don't overdo it in the beginning. It's okay if you only send **one** signal, named `App.launched`. This will already give you number of users, number of launches, system versions, retention, and more!
 
-After a while, you can add a send call for each screen in your app, so you can see which screens your users use most. It's also recommended to add all your custom settings to your metadata each time (except the ones that might identify an individual user please). This way you can see which settings most of your users use.
+After a while, you can add a signal for each screen in your app, so you can see which screens your users use most. It's also recommended to add all your custom settings to your metadata each time. This way you can see which settings most of your users use.

--- a/guides/swift-setup.md
+++ b/guides/swift-setup.md
@@ -9,7 +9,7 @@ tags:
 featured: true
 testedOn: Xcode 14.1 & Swift 5.5
 description: Configure the TelemetryDeck SDK in Your Swift Application for iOS, macOS, watchOS and tvOS
-lead: Let's include the TelemetryClient Swift Package in your application and send signals!
+lead: Let's include the TelemetryDeck Swift Package in your application and send signals!
 order: 100
 ---
 
@@ -23,8 +23,8 @@ The TelemetryDeck Swift package uses Swift Package Manager.
 
 1. Open Xcode and navigate to the project you want to add TelemetryDeck to.
 1. In the menu, select <kbd>File</kbd> -> <kbd>Add Packages...</kbd>. This will open the Swift Package Manager view.
-1. Paste `https://github.com/TelemetryDeck/SwiftClient` into the search field.
-1. Select the `SwiftClient` package that appears in the list
+1. Paste `https://github.com/TelemetryDeck/SwiftSDK` into the search field.
+1. Select the `SwiftSDK` package that appears in the list
 1. Set the <kbd>Dependency Rule</kbd> to <kbd>Up to Next Major Version</kbd>.
 1. Click <kbd>Add Package</kbd>.
 
@@ -34,16 +34,16 @@ This will include the TelemetryDeck Swift Client into your app by downloading th
 
 ## Including the package in your target
 
-Xcode will ask you to link the package with your target in the next screen, titles <kbd>Choose Package Products for SwiftClient</kbd>. Select the `TelemetryClient` library and click <kbd>Add Package</kbd>.
+Xcode will ask you to link the package with your target in the next screen, titles <kbd>Choose Package Products for SwiftSDK</kbd>. Select the `TelemetryDeck` library and click <kbd>Add Package</kbd>.
 
 {% noteinfo "Link Library with more than one Target" %}
 
-In case Xcode forgets to ask you to link the library with your target, you can do so manually by selecting your target in the project navigator and selecting the <kbd>Build Phases</kbd> tab. Click the <kbd>+</kbd> button in the <kbd>Link Binary With Libraries</kbd> section and select the `TelemetryClient` library.
+In case Xcode forgets to ask you to link the library with your target, you can do so manually by selecting your target in the project navigator and selecting the <kbd>Build Phases</kbd> tab. Click the <kbd>+</kbd> button in the <kbd>Link Binary With Libraries</kbd> section and select the `TelemetryDeck` library.
 {% endnoteinfo %}
 
 ## Initializing the TelemetryDeck Swift Package
 
-The `TelemetryClient` package will provide you with a class `TelemetryManager` that you'll use for all interactions with TelemetryDeck. Before you can use that class, you'll need to initialize it at the start of your app. We strongly recommend doing so as soon as possible, as you won't be able to send Signals before the `TelemetryManager` is initialized.
+The `TelemetryDeck` package will provide you with a class `TelemetryDeck` that you'll use for all interactions with TelemetryDeck. Before you can use that class, you'll need to initialize it at the start of your app. We strongly recommend doing so as soon as possible, as you won't be able to send Signals before the `TelemetryDeck` is initialized.
 
 This is slightly different depending on whether you use SwiftUI or UIKit's `AppDelegate` to manage your app's lifecycle, so let's look at these individually.
 
@@ -74,13 +74,13 @@ struct Example_AppApp: App {
 
 This is the entry point to your app. Now let's add the initialization here.
 
-Import the TelemetryClient Package by adding `import TelemetryClient`. Then add an `init()` method to your App struct that creates a `TelemetryManagerConfiguration` instance and hands it to the `TelemetryManager`, using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore, you can get it at any time from the TelemetryDeck Dashboard.
+Import the TelemetryDeck Package by adding `import TelemetryDeck`. Then add an `init()` method to your App struct that creates a `TelemetryDeck.Config` instance and hands it to the `TelemetryDeck`, using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore, you can get it at any time from the TelemetryDeck Dashboard.
 
 Your code should now look like this:
 
 ```swift
 import SwiftUI
-import TelemetryClient
+import TelemetryDeck
 
 @main
 struct Example_AppApp: App {
@@ -91,9 +91,8 @@ struct Example_AppApp: App {
     }
 
     init() {
-        let configuration = TelemetryManagerConfiguration(
-            appID: "YOUR-APP-UNIQUE-IDENTIFIER")
-        TelemetryManager.initialize(with: configuration)
+        let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
+        TelemetryDeck.initialize(config: config)
     }
 }
 ```
@@ -122,19 +121,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 By default, Xcode even adds a comment here to tell you where to add stuff that should happen right after launch.
 
-Now, import the `TelemetryClient` package and configure the `TelemetryManager` using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore you can get it at any time from the TelemetryDeck Dashboard.
+Now, import the `TelemetryDeck` package and configure the `TelemetryDeck` using the **Unique Identifier of your app** that you copied into your clipboard earlier. If you don't have that anymore you can get it at any time from the TelemetryDeck Dashboard.
 
 ```swift
 import UIKit
-import TelemetryClient
+import TelemetryDeck
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        let configuration = TelemetryManagerConfiguration(
-            appID: "YOUR-APP-UNIQUE-IDENTIFIER")
-        TelemetryManager.initialize(with: configuration)
+        let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
+        TelemetryDeck.initialize(config: config)
 
         return true
     }
@@ -166,25 +164,26 @@ See the [Signals Reference](/docs/api/signals-reference/) for more information a
 If your app is built in `DEBUG` configuration (i.e. running from Xcode), your signals will be tagged as **Testing Signals**, meaning that you can easily filter them out later. You'll see them show up in the TelemetryDeck Dashboard when it is set to **Test Mode**.
 {% endnotewarning %}
 
-See the [TelemetryDeck SDK's `README.md` file](https://github.com/TelemetryDeck/SwiftClient/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to the place where you just added the initialization, and directly below add this line:
+See the [TelemetryDeck SDK's `README.md` file](https://github.com/TelemetryDeck/SwiftSDK/blob/main/README.md) for more information on how to send signals. For now, let's just send one signal that tells us the app has launched. Go to the place where you just added the initialization, and directly below add this line:
 
 ```swift
-let configuration = TelemetryManagerConfiguration(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
-TelemetryManager.initialize(with: configuration)
+let config = TelemetryDeck.Config(appID: "YOUR-APP-UNIQUE-IDENTIFIER")
+TelemetryDeck.initialize(config: config)
 
-TelemetryManager.send("applicationDidFinishLaunching")
+TelemetryDeck.signal("App.didFinishLaunching")
 ```
 
-And done. This is all you need to send a signal. You do not need to keep an instance of TelemetryManager and hand it around, just call the `send` function on the class directly. If you want to add a custom user identifer or metadata payload, add them to the function call like this:
+And done. This is all you need to send a signal. You do not need to keep an instance of TelemetryDeck and hand it around, just call the `send` function on the class directly. If you want to add a custom user identifer or metadata payload, add them to the function call like this:
 
 ```swift
-TelemetryManager.send(
-    "applicationDidFinishLaunching",
-    for: "my very cool user",
-    with: [
+TelemetryDeck.signal(
+    "App.didFinishLaunching",
+    parameters: [
         "numberOfTimesPizzaModeHasActivated": "\(dataStore.pizzaMode.count)",
         "pizzaCheeseMode": "\(dataStore.pizzaCheeseMode)"
-    ])
+    ],
+    customUserID: "my very cool user"
+)
 ```
 
 And you're done! You are now sending signals to the TelemetryDeck server.

--- a/integrations/superwall.md
+++ b/integrations/superwall.md
@@ -44,16 +44,16 @@ class SuperwallService: SuperwallDelegate {
             stringifiedParams[param.key] = String(describing: param.value)
         }
 
-        TelemetryManager.send(eventInfo.event.description, with: stringifiedParams)
+        TelemetryDeck.signal(eventInfo.event.description, parameters: stringifiedParams)
     }
 }
 ```
 
-Because TelemetryDeck only accepts strings as event metadata, this method accepts all data from Superwall, stringifies it, and hands it off to TelemetryDeck. The TelemetryManager takes care of queuing and sending the events to TelemetryDeck.
+Because TelemetryDeck only accepts strings as event metadata, this method accepts all data from Superwall, stringifies it, and hands it off to TelemetryDeck. The TelemetryDeck takes care of queuing and sending the events to TelemetryDeck.
 
 ## Registering the Superwall delegate
 
-Now that we have a delegate, we have to register it with Superwall. We can do this in the function that you initialize TelemetryDeck and Superwall in. This is usually in your `App` struct or `AppDelegate`. When in doubt, search for `TelemetryManager.initialize` in your project.
+Now that we have a delegate, we have to register it with Superwall. We can do this in the function that you initialize TelemetryDeck and Superwall in. This is usually in your `App` struct or `AppDelegate`. When in doubt, search for `TelemetryDeck.initialize` in your project.
 
 Add the following line to the function, making sure it is below the initialization code for both TelemetryDeck and Superwall:
 


### PR DESCRIPTION
@winsmith These are my renaming suggestions. If approved, I can create pull requests on all mobile SDKs that apply them. I would also go through other docs and adjust references accordingly once approved, I only adjusted one article so far.

TODOs that still need to be discussed or are out of my scope are:

- [ ] Renaming the SwiftClient to Swift SDK on GitHub. (As long as you don't create a new repo with the old name, GitHub will redirect to the new name automatically.)
- [ ] I marked all the Android lifecycle signals as "Deleted" assuming they would get deleted. Maybe I should even remove them from the list here, but they are currently there, so I added them so we can discuss.