### PR TITLE
Add new parameters to default params article (mostly accessibility)

### DIFF
--- a/api/default-parameters.md
+++ b/api/default-parameters.md
@@ -10,127 +10,127 @@ Most of TelemetryDeck's SDKs send a set of default parameters with every signal.
 
 These parameters are sent with every signal and are currently not namespaced. Please avoid using them in your own code.
 
-- `appID`: The ID of the app.
-- `clientUser`: The ID of the user.
-- `type`: The type of the signal.
-- `receivedAt`: The date and time the signal was received by TelemetryDeck.
-- `count`: The number of events sent with the signal (automatically incremented by the server)
-- `isTestMode`: Whether the signal was sent in test mode.
-- `sessionID`: The ID of the session.
-- `floatValue`: A float value that can be sent with the signal.
+- `appID` (String): The ID of the app.
+- `clientUser` (String): The ID of the user.
+- `type` (String): The type of the signal.
+- `receivedAt` (Date): The date and time the signal was received by TelemetryDeck.
+- `count` (Int): The number of events sent with the signal (automatically incremented by the server)
+- `isTestMode` (Bool): Whether the signal was sent in test mode.
+- `sessionID` (String): The ID of the session.
+- `floatValue` (Double): A float value that can be sent with the signal.
 
 ## App Info
 
 Information about the specific app build, such as version, build number, or SDKs compiled with.
 
-- `TelemetryDeck.AppInfo.buildNumber`: The build number of the app.
-- `TelemetryDeck.AppInfo.version`: The version of the app.
-- `TelemetryDeck.AppInfo.versionAndBuildNumber`: The version and build number of the app, separated by a space.
+- `TelemetryDeck.AppInfo.buildNumber` (String): The build number of the app.
+- `TelemetryDeck.AppInfo.version` (String): The version of the app.
+- `TelemetryDeck.AppInfo.versionAndBuildNumber` (String): The version and build number of the app, separated by a space.
 
 ## Device
 
 Information about the device running the application, such as operating system, model name, or architecture.
 
-- `TelemetryDeck.Device.architecture`: The architecture of the device.
-- `TelemetryDeck.Device.modelName`: The model name of the device.
-- `TelemetryDeck.Device.operatingSystem`: The operating system of the device.
-- `TelemetryDeck.Device.orientation`: The orientation of the device.
-- `TelemetryDeck.Device.platform`: The platform of the device.
-- `TelemetryDeck.Device.screenResolutionHeight`: The height of the screen in points.
-- `TelemetryDeck.Device.screenResolutionWidth`: The width of the screen in points.
-- `TelemetryDeck.Device.screenScaleFactor`: The scale factor to calculate pixels from points (e.g. `2.0` for Retina).
-- `TelemetryDeck.Device.systemMajorMinorVersion`: The major and minor version of the operating system.
-- `TelemetryDeck.Device.systemMajorVersion`: The major version of the operating system.
-- `TelemetryDeck.Device.systemVersion`: The version of the operating system.
-- `TelemetryDeck.Device.timeZone`: The time zone of the device.
-- `TelemetryDeck.Device.screenDensity`: The screen density of the device.
-- `TelemetryDeck.Device.brand`: The brand of the device.
+- `TelemetryDeck.Device.architecture` (String): The architecture of the device.
+- `TelemetryDeck.Device.modelName` (String): The model name of the device.
+- `TelemetryDeck.Device.operatingSystem` (String): The operating system of the device.
+- `TelemetryDeck.Device.orientation` (String): The orientation of the device.
+- `TelemetryDeck.Device.platform` (String): The platform of the device.
+- `TelemetryDeck.Device.screenResolutionHeight` (Double): The height of the screen in points.
+- `TelemetryDeck.Device.screenResolutionWidth` (Double): The width of the screen in points.
+- `TelemetryDeck.Device.screenScaleFactor` (Double): The scale factor to calculate pixels from points (e.g. `2.0` for Retina).
+- `TelemetryDeck.Device.systemMajorMinorVersion` (String): The major and minor version of the operating system.
+- `TelemetryDeck.Device.systemMajorVersion` (String): The major version of the operating system.
+- `TelemetryDeck.Device.systemVersion` (String): The version of the operating system.
+- `TelemetryDeck.Device.timeZone` (String): The time zone of the device.
+- `TelemetryDeck.Device.screenDensity` (Double): The screen density of the device.
+- `TelemetryDeck.Device.brand` (String): The brand of the device.
 
 ## Run Context
 
 Information about the context the app runs in, such as whether it's running in a simulator, debug mode, or target environment.
 
-- `TelemetryDeck.RunContext.isAppStore`: Whether the app is running in the App Store.
-- `TelemetryDeck.RunContext.isDebug`: Whether the app is running in debug mode.
-- `TelemetryDeck.RunContext.isSimulator`: Whether the app is running in a simulator.
-- `TelemetryDeck.RunContext.isTestFlight`: Whether the app is running in TestFlight.
-- `TelemetryDeck.RunContext.language`: The language of the app.
-- `TelemetryDeck.RunContext.locale`: The locale of the app.
-- `TelemetryDeck.RunContext.targetEnvironment`: The target environment of the app.
-- `TelemetryDeck.RunContext.extensionIdentifier`: The identifier of the extension the app is running in. This provides a value such as `com.apple.widgetkit-extension` when TelemetryDeck is run from a widget.
-- `TelemetryDeck.RunContext.isSideLoaded`: Whether the app is running as a side loaded app.
-- `TelemetryDeck.RunContext.sourceMarketplace`: The source marketplace of the app.
+- `TelemetryDeck.RunContext.isAppStore` (Bool): Whether the app is running in the App Store.
+- `TelemetryDeck.RunContext.isDebug` (Bool): Whether the app is running in debug mode.
+- `TelemetryDeck.RunContext.isSimulator` (Bool): Whether the app is running in a simulator.
+- `TelemetryDeck.RunContext.isTestFlight` (Bool): Whether the app is running in TestFlight.
+- `TelemetryDeck.RunContext.language` (String): The language of the app.
+- `TelemetryDeck.RunContext.locale` (String): The locale of the app.
+- `TelemetryDeck.RunContext.targetEnvironment` (String): The target environment of the app.
+- `TelemetryDeck.RunContext.extensionIdentifier` (String): The identifier of the extension the app is running in. This provides a value such as `com.apple.widgetkit-extension` when TelemetryDeck is run from a widget.
+- `TelemetryDeck.RunContext.isSideLoaded` (Bool): Whether the app is running as a side loaded app.
+- `TelemetryDeck.RunContext.sourceMarketplace` (String): The source marketplace of the app.
 
 ## User Preference
 
 Information about the user's preferences, such as language and region.
 
-- `TelemetryDeck.UserPreference.colorScheme`: `Dark` or `Light`, depending on the user preference.
-- `TelemetryDeck.UserPreference.language`: The language of the user.
-- `TelemetryDeck.UserPreference.layoutDirection`: `leftToRight` or `rightToLeft`, based on user preference.
-- `TelemetryDeck.UserPreference.region`: The region of the user.
+- `TelemetryDeck.UserPreference.colorScheme` (Enum): `Dark` or `Light`, depending on the user preference.
+- `TelemetryDeck.UserPreference.language` (String): The language of the user.
+- `TelemetryDeck.UserPreference.layoutDirection` (Enum): `leftToRight` or `rightToLeft`, based on user preference.
+- `TelemetryDeck.UserPreference.region` (String): The region of the user.
 
 ## SDK
 
 Information about the TelemetryDeck SDK, such as its name or version number.
 
-- `TelemetryDeck.SDK.name`: The name of the SDK.
-- `TelemetryDeck.SDK.nameAndVersion`: The name and version of the SDK, separated by a space.
-- `TelemetryDeck.SDK.version`: The version of the SDK.
-- `TelemetryDeck.SDK.buildType`: The build type of the SDK.
+- `TelemetryDeck.SDK.name` (String): The name of the SDK.
+- `TelemetryDeck.SDK.nameAndVersion` (String): The name and version of the SDK, separated by a space.
+- `TelemetryDeck.SDK.version` (String): The version of the SDK.
+- `TelemetryDeck.SDK.buildType` (String): The build type of the SDK.
 
 ## Accessibility
 
 Information about the user's accessibility device settings to help make apps more inclusive.
 
-- `TelemetryDeck.Accessibility.isReduceMotionEnabled`: Whether Reduce Motion is enabled.
-- `TelemetryDeck.Accessibility.isBoldTextEnabled`: Whether Bold Text is enabled.
-- `TelemetryDeck.Accessibility.isInvertColorsEnabled`: Whether Invert Colors is enabled.
-- `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`: Whether Darker System Colors are enabled.
-- `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`: Whether Reduce Transparency is enabled.
-- `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor`: Whether UI should differentiate without color.
-- `TelemetryDeck.Accessibility.preferredContentSizeCategory`: User's preferred text size category (e.g. `L`, `XXL`).
+- `TelemetryDeck.Accessibility.isReduceMotionEnabled` (Bool): Whether Reduce Motion is enabled.
+- `TelemetryDeck.Accessibility.isBoldTextEnabled` (Bool): Whether Bold Text is enabled.
+- `TelemetryDeck.Accessibility.isInvertColorsEnabled` (Bool): Whether Invert Colors is enabled.
+- `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled` (Bool): Whether Darker System Colors are enabled.
+- `TelemetryDeck.Accessibility.isReduceTransparencyEnabled` (Bool): Whether Reduce Transparency is enabled.
+- `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` (Bool): Whether UI should differentiate without color.
+- `TelemetryDeck.Accessibility.preferredContentSizeCategory` (String): User's preferred text size category (e.g. `L`, `XXL`).
 
 ## API
 
-Information about which TelemetryDeck API this signal was sent to .
+Information about which TelemetryDeck API this signal was sent to.
 
-- `TelemetryDeck.API.Ingest.version`: The Ingest API Version this signal was sent to. This will get overwritten by the ingest API server.
-
-## Deprecated Parameters
-
-These parameters are deprecated because they are not yet namespaced, and will be removed in a future release. All of them have replacements in some name spaces. See the [grand rename](/articles/grand-rename/) article for a mapping of the old names to the new ones.
-
-- `platform`: The platform of the device.
-- `systemVersion`: The version of the operating system.
-- `majorSystemVersion`: The major version of the operating system.
-- `majorMinorSystemVersion`: The major and minor version of the operating system.
-- `appVersion`: The version of the app.
-- `buildNumber`: The build number of the app.
-- `isSimulator`: Whether the app is running in a simulator.
-- `isDebug`: Whether the app is running in debug mode.
-- `isTestFlight`: Whether the app is running in TestFlight.
-- `isAppStore`: Whether the app is running in the App Store.
-- `modelName`: The model name of the device.
-- `architecture`: The architecture of the device.
-- `operatingSystem`: The operating system of the device.
-- `targetEnvironment`: The target environment of the app.
-- `locale`: The locale of the app.
-- `region`: The region of the user.
-- `appLanguage`: The language of the app.
-- `preferredLanguage`: The preferred language of the user.
-- `telemetryClientVersion`: The version of the TelemetryDeck SDK.
-- `telemetryAPIVersion`: The API Version this signal was sent to
+- `TelemetryDeck.API.Ingest.version` (String): The Ingest API Version this signal was sent to. This will get overwritten by the ingest API server.
 
 ## RevenueCat Parameters
 
 Parameters related to RevenueCat.
 
-- `RevenueCat.event.commission_percentage`
-- `RevenueCat.event.price`
-- `RevenueCat.event.price_in_purchased_currency`
-- `RevenueCat.event.takehome_percentage`
-- `RevenueCat.event.tax_percentage`
+- `RevenueCat.event.commission_percentage` (Double)
+- `RevenueCat.event.price` (Double)
+- `RevenueCat.event.price_in_purchased_currency` (Double)
+- `RevenueCat.event.takehome_percentage` (Double)
+- `RevenueCat.event.tax_percentage` (Double)
+
+## Deprecated Parameters
+
+These parameters are deprecated because they are not yet namespaced, and will be removed in a future release. All of them have replacements in some name spaces. See the [grand rename](/articles/grand-rename/) article for a mapping of the old names to the new ones.
+
+- `platform` (String): The platform of the device.
+- `systemVersion` (String): The version of the operating system.
+- `majorSystemVersion` (String): The major version of the operating system.
+- `majorMinorSystemVersion` (String): The major and minor version of the operating system.
+- `appVersion` (String): The version of the app.
+- `buildNumber` (String): The build number of the app.
+- `isSimulator` (Bool): Whether the app is running in a simulator.
+- `isDebug` (Bool): Whether the app is running in debug mode.
+- `isTestFlight` (Bool): Whether the app is running in TestFlight.
+- `isAppStore` (Bool): Whether the app is running in the App Store.
+- `modelName` (String): The model name of the device.
+- `architecture` (String): The architecture of the device.
+- `operatingSystem` (String): The operating system of the device.
+- `targetEnvironment` (String): The target environment of the app.
+- `locale` (String): The locale of the app.
+- `region` (String): The region of the user.
+- `appLanguage` (String): The language of the app.
+- `preferredLanguage` (String): The preferred language of the user.
+- `telemetryClientVersion` (String): The version of the TelemetryDeck SDK.
+- `telemetryAPIVersion` (String): The API Version this signal was sent to.
 
 ## Reserved Parameters
 

--- a/api/default-parameters.md
+++ b/api/default-parameters.md
@@ -83,7 +83,6 @@ Information about the TelemetryDeck SDK, such as its name or version number.
 
 Information about the user's accessibility device settings to help make apps more inclusive.
 
-- `TelemetryDeck.Accessibility.isVoiceOverEnabled`: Whether VoiceOver is running.
 - `TelemetryDeck.Accessibility.isReduceMotionEnabled`: Whether Reduce Motion is enabled.
 - `TelemetryDeck.Accessibility.isBoldTextEnabled`: Whether Bold Text is enabled.
 - `TelemetryDeck.Accessibility.isInvertColorsEnabled`: Whether Invert Colors is enabled.
@@ -91,7 +90,6 @@ Information about the user's accessibility device settings to help make apps mor
 - `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`: Whether Reduce Transparency is enabled.
 - `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor`: Whether UI should differentiate without color.
 - `TelemetryDeck.Accessibility.preferredContentSizeCategory`: User's preferred text size category (e.g. `L`, `XXL`).
-- `TelemetryDeck.Accessibility.isSwitchControlEnabled`: Whether Switch Control is running.
 
 ## API
 

--- a/api/default-parameters.md
+++ b/api/default-parameters.md
@@ -36,8 +36,9 @@ Information about the device running the application, such as operating system, 
 - `TelemetryDeck.Device.operatingSystem`: The operating system of the device.
 - `TelemetryDeck.Device.orientation`: The orientation of the device.
 - `TelemetryDeck.Device.platform`: The platform of the device.
-- `TelemetryDeck.Device.screenResolutionHeight`: The height of the screen in pixels.
-- `TelemetryDeck.Device.screenResolutionWidth`: The width of the screen in pixels.
+- `TelemetryDeck.Device.screenResolutionHeight`: The height of the screen in points.
+- `TelemetryDeck.Device.screenResolutionWidth`: The width of the screen in points.
+- `TelemetryDeck.Device.screenScaleFactor`: The scale factor to calculate pixels from points (e.g. `2.0` for Retina).
 - `TelemetryDeck.Device.systemMajorMinorVersion`: The major and minor version of the operating system.
 - `TelemetryDeck.Device.systemMajorVersion`: The major version of the operating system.
 - `TelemetryDeck.Device.systemVersion`: The version of the operating system.
@@ -64,7 +65,9 @@ Information about the context the app runs in, such as whether it's running in a
 
 Information about the user's preferences, such as language and region.
 
+- `TelemetryDeck.UserPreference.colorScheme`: `Dark` or `Light`, depending on the user preference.
 - `TelemetryDeck.UserPreference.language`: The language of the user.
+- `TelemetryDeck.UserPreference.layoutDirection`: `leftToRight` or `rightToLeft`, based on user preference.
 - `TelemetryDeck.UserPreference.region`: The region of the user.
 
 ## SDK
@@ -75,6 +78,20 @@ Information about the TelemetryDeck SDK, such as its name or version number.
 - `TelemetryDeck.SDK.nameAndVersion`: The name and version of the SDK, separated by a space.
 - `TelemetryDeck.SDK.version`: The version of the SDK.
 - `TelemetryDeck.SDK.buildType`: The build type of the SDK.
+
+## Accessibility
+
+Information about the user's accessibility device settings to help make apps more inclusive.
+
+- `TelemetryDeck.Accessibility.isVoiceOverEnabled`: Whether VoiceOver is running.
+- `TelemetryDeck.Accessibility.isReduceMotionEnabled`: Whether Reduce Motion is enabled.
+- `TelemetryDeck.Accessibility.isBoldTextEnabled`: Whether Bold Text is enabled.
+- `TelemetryDeck.Accessibility.isInvertColorsEnabled`: Whether Invert Colors is enabled.
+- `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`: Whether Darker System Colors are enabled.
+- `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`: Whether Reduce Transparency is enabled.
+- `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor`: Whether UI should differentiate without color.
+- `TelemetryDeck.Accessibility.preferredContentSizeCategory`: User's preferred text size category (e.g. `L`, `XXL`).
+- `TelemetryDeck.Accessibility.isSwitchControlEnabled`: Whether Switch Control is running.
 
 ## API
 


### PR DESCRIPTION
I updated the docs according to the recent changes in the Swift SDK.

I've also added the types for each parameter as far as I knew. I will add the Pirate Metrics parameters here so this becomes the document you requested with all parameters and their types in it. @winsmith 