### PR TITLE
TelemetryManager.shared.hashedDefaultUser is not optional

### DIFF
--- a/integrations/revenuecat.md
+++ b/integrations/revenuecat.md
@@ -72,8 +72,7 @@ TelemetryDeck.updateDefaultUserID(to: myUserID)
 Purchases.configure(withAPIKey: "my_revenuecat_api_key")
 Purchases.shared.attribution.setAttributes([
     "$telemetryDeckUserId": TelemetryManager.shared
-        .hashedDefaultUser
-        ?? "no-user",
+        .hashedDefaultUser,
     "$telemetryDeckAppId": telemetrydeckAppID
 ])
 ```


### PR DESCRIPTION
TelemetryManager.shared.hashedDefaultUser is not optional, updated documentation to reflect this